### PR TITLE
Add support for fused reorder kernel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ lm-evaluation-harness/lm_eval/datasets/*/__pycache__/
 lm-evaluation-harness/lm_eval/*/__pycache__/
 lm-evaluation-harness/lm_eval/__pycache__/
 lm-evaluation-harness/lm_cache
+/CMakeLists.txt

--- a/convert_legacy_model_format.py
+++ b/convert_legacy_model_format.py
@@ -4,7 +4,7 @@ import os
 import torch
 from transformers import AutoConfig, AutoModelForCausalLM
 
-from inference_lib.src.inference import ModelArgs, QuantizedLinear, SPQRLegacy
+from inference_lib.spqr_quant.inference import ModelArgs, SPQRLegacy, QuantizedLinear
 
 
 def load_legacy_tensor(p: str, model_args: ModelArgs) -> SPQRLegacy:

--- a/inference_demo.py
+++ b/inference_demo.py
@@ -1,4 +1,3 @@
-import os
 import time
 from enum import IntEnum
 from typing import Tuple
@@ -172,7 +171,7 @@ if __name__ == "__main__":
     m = Mode(args.execution_mode)
 
     with torch.no_grad():
-        model = InferenceDemo(args.pretrained_model_path, args.compressed_model_path, m, backend="inductor")
+        model = InferenceDemo(args.pretrained_model_path, args.compressed_model_path, m)
         text = "The recipe for banana bread is "  # input()
         s = time.time()
         generated_text, timings_s = model.generate(text, max_new_tokens=128)
@@ -183,5 +182,6 @@ if __name__ == "__main__":
 
         durations = np.array(timings_s[16:])
 
-        print(f"Mean duration after caching initial input = {durations.mean()}")
-        print(f"Median duration after caching initial input = {np.median(durations)}")
+        print(f'Mean duration after caching initial input = {durations.mean()}')
+        print(f'Median duration after caching initial input = {np.median(durations)}')
+        print(f'Best duration after caching initial input = {np.min(durations)}')

--- a/inference_lib/spqr_quant/__init__.py
+++ b/inference_lib/spqr_quant/__init__.py
@@ -1,2 +1,2 @@
 from .inference import QuantizedLinear
-from .inference_kernels import get_spqr_mul
+from .inference_kernels import get_spqr_mul_timer, get_torch_mul_timer, get_spqr_mul_fused

--- a/inference_lib/spqr_quant/inference_kernels/__init__.py
+++ b/inference_lib/spqr_quant/inference_kernels/__init__.py
@@ -1,1 +1,1 @@
-from .kernel_selector import get_spqr_mul
+from .kernel_selector import get_spqr_mul_fused, get_spqr_mul_timer, get_torch_mul_timer

--- a/inference_lib/spqr_quant/inference_kernels/cuda_kernel.py
+++ b/inference_lib/spqr_quant/inference_kernels/cuda_kernel.py
@@ -8,9 +8,8 @@ SPQR_CUDA = load(
     name="spqr_cuda",
     sources=[os.path.join(CUDA_FOLDER, "spqr_cuda.cpp"), os.path.join(CUDA_FOLDER, "spqr_cuda_kernel.cu")],
     extra_cflags=["-O3"],
-    extra_cuda_cflags=["-O3", "-arch=native"],
+    extra_cuda_cflags=["-O3", "-arch=native", '-lineinfo'],
 )
-
 
 torch.library.define(
     "spqr_cuda::dequantize_compressed",
@@ -32,12 +31,17 @@ torch.library.define(
     "spqr_cuda::tensor_compress_interleaved",
     "(int m, int n, int bits, Tensor W, int beta1, int beta2, Tensor W_s, Tensor W_z, Tensor W_s_s, Tensor W_s_z, Tensor W_z_s, Tensor W_z_z, Tensor row_offsets, Tensor row_offsets_output, Tensor col_vals, Tensor col_vals_interleaved, int sparse_strategy_compression, Tensor out) -> ()",
 )
+torch.library.define(
+    "spqr_cuda::spqr_mul_fused",
+    "(int m, int n, int bits, int beta1, int beta2, Tensor in_perm, Tensor dense_weights, Tensor row_offsets, Tensor col_vals, int nnz, Tensor x, int f, Tensor Y, Tensor(Y!) out) -> ()"
+)
 
 torch.library.impl("spqr_cuda::torch_mul_timer", "default", SPQR_CUDA.torch_mul_timer)
 torch.library.impl("spqr_cuda::tensor_compress_interleaved", "default", SPQR_CUDA.tensor_compress_interleaved)
 torch.library.impl("spqr_cuda::spqr_mul_timer", "default", SPQR_CUDA.spqr_mul_timer)
 torch.library.impl("spqr_cuda::spqr_mul", "default", SPQR_CUDA.spqr_mul)
 torch.library.impl("spqr_cuda::dequantize_compressed", "default", SPQR_CUDA.dequantize_compressed)
+torch.library.impl("spqr_cuda::spqr_mul_fused", "default", SPQR_CUDA.spqr_mul_fused)
 
 
 def call_spqr_mul(*args):
@@ -60,6 +64,10 @@ def call_dequantize_compressed(*args):
     return torch.ops.spqr_cuda.dequantize_compressed(*args)
 
 
+def call_spqr_mul_fused(*args):
+    return torch.ops.spqr_cuda.spqr_mul_fused(*args)
+
+
 @torch.library.register_fake("spqr_cuda::spqr_mul")
 def spqr_mul_meta(m, n, bits, beta1, beta2, dense_weights, row_offsets, col_vals, nnz, x, f, Y, out):
     return
@@ -67,4 +75,9 @@ def spqr_mul_meta(m, n, bits, beta1, beta2, dense_weights, row_offsets, col_vals
 
 @torch.library.register_fake("spqr_cuda::spqr_mul_timer")
 def spqr_mul_timer_meta(m, n, bits, beta1, beta2, dense_weights, row_offsets, col_vals, nnz, x, f, Y, out):
+    return
+
+
+@torch.library.register_fake("spqr_cuda::spqr_mul_fused")
+def spqr_mul_fused_meta(m, n, bits, beta1, beta2, in_perm, dense_weights, row_offsets, col_vals, nnz, x, f, Y, out):
     return

--- a/inference_lib/spqr_quant/inference_kernels/kernel_selector.py
+++ b/inference_lib/spqr_quant/inference_kernels/kernel_selector.py
@@ -1,10 +1,10 @@
 import torch
 
 
-def get_spqr_mul():
+def get_spqr_mul_fused():
     from .cuda_kernel import CUDA_FOLDER
 
-    return torch.ops.spqr_cuda.spqr_mul
+    return torch.ops.spqr_cuda.spqr_mul_fused
 
 
 def get_spqr_mul_timer():
@@ -17,3 +17,8 @@ def get_torch_mul_timer():
     from .cuda_kernel import CUDA_FOLDER
 
     return torch.ops.spqr_cuda.torch_mul_timer
+
+def get_spqr_mul():
+    from .cuda_kernel import CUDA_FOLDER
+
+    return torch.ops.spqr_cuda.spqr_mul

--- a/inference_lib/spqr_quant/inference_kernels/spqr_cuda_kernel.cu
+++ b/inference_lib/spqr_quant/inference_kernels/spqr_cuda_kernel.cu
@@ -139,11 +139,27 @@ DEVICE_INLINE half get_val(u32 m) {
             dim3(__min(updiv(prob_n, 16), BLOCK_WIDTH) * 16, __min(updiv(prob_m, 16), BLOCK_HEIGHT), 1), smem_size, \
             stream>>>(prob_m, \
             prob_n, \
+            order_ptr, \
             raw_data_ptr,                               \
             X_ptr, \
             row_offsets_ptr, \
             col_vals_ptr, \
-            order_ptr, \
+            y_ptr);
+
+
+#define CALL_MATVEC(F, _BLOCK_HEIGHT, _BLOCK_WIDTH, PIPELINE_DEPTH, IS_CSR) \
+    constexpr int BLOCK_HEIGHT = _BLOCK_HEIGHT; \
+    constexpr int BLOCK_WIDTH = _BLOCK_WIDTH; \
+    size_t smem_size = sizeof(half2) * prob_n / 2;                   \
+    F<3, 16, 16, BLOCK_HEIGHT, BLOCK_WIDTH, u64, PIPELINE_DEPTH, IS_CSR> \
+            <<<dim3(updiv(prob_m, 16 * BLOCK_HEIGHT), 1, 1), \
+            dim3(__min(updiv(prob_n, 16), BLOCK_WIDTH) * 16, __min(updiv(prob_m, 16), BLOCK_HEIGHT), 1), smem_size, \
+            stream>>>(prob_m, \
+            prob_n, \
+            raw_data_ptr,                               \
+            X_ptr, \
+            row_offsets_ptr, \
+            col_vals_ptr, \
             y_ptr);
 
 
@@ -177,7 +193,245 @@ constexpr bool PIPELINED_LOAD = false;
 #define INT2_TO_HALF2(v) s_half2_lut[v]
 
 template<int BITS, int BETA1, int BETA2, int BLOCK_HEIGHT, int BLOCK_WIDTH, class W_t /* = uint64_t */, int
-  PIPELINE_DEPTH, bool IS_CSR> __global__ void spqr_quantized_matvec_fused_csr(
+  PIPELINE_DEPTH, bool IS_CSR> __global__ void spqr_quantized_matvec_fused(
+  // W and meta
+  unsigned int prob_m,
+  unsigned int prob_n,
+  const uint16_t * __restrict__ in_order,
+  // W 1st order stats
+  const W_t *__restrict__ dense_matrix,
+  const half *__restrict__ x,
+  // Outliers
+  const int *__restrict__ row_offsets,
+  const u32 *__restrict__ col_vals,
+  // Output
+  half *__restrict__ y_fp16) {
+  /*
+           ┌─────────────┐ ┌─┐   ┌─┐
+   beta1   │   block 0   │ │ │   │ │
+           ├─────────────┤ │ │   │ │
+   beta1   │   block 1   │ │ │   │ │
+           └─────────────┘ │x│ = │Y│
+           │    ...      │ │ │   │ │
+           ┌─────────────┐ │ │   │ │
+   beta1   │  block m-1  │ │ │   │ │
+           └─────────────┘ └─┘   └─┘
+  */
+  static constexpr u32 WARP_SIZE = 32;
+  static constexpr u32 HALF_WARP_SIZE = WARP_SIZE / 2;
+
+  static constexpr u32 NUM_HALF_WARPS = BLOCK_HEIGHT * BLOCK_WIDTH;
+  static constexpr u32 NUM_WARPS = UPDIV(NUM_HALF_WARPS, 2);
+  static constexpr u32 THREAD_COUNT = BLOCK_HEIGHT * BLOCK_WIDTH * HALF_WARP_SIZE;
+  static constexpr u32 OUTPUT_SIZE = BETA1 * BLOCK_HEIGHT;
+  static constexpr u32 ROW_OFFSETS_SIZE = IS_CSR ? OUTPUT_SIZE : 1;
+
+  constexpr int X_LOAD_BLOCK_SIZE = 2;
+
+  extern __shared__ half2 s_x2[];
+  static constexpr u32 LUT_SIZE = 64 * NUM_WARPS;
+  __shared__ half2 s_half2_lut_global[LUT_SIZE];
+
+  __shared__ u32 s_row_offsets[ROW_OFFSETS_SIZE + 1];
+
+  const u32 thread_xy = threadIdx.x + (threadIdx.y * blockDim.x);
+
+  if constexpr (THREAD_COUNT >= 64) {
+    const auto v = make_half2(__int2half_rd(thread_xy & 0b111), __int2half_rd((thread_xy >> 3) & 0b111));
+#pragma unroll
+    for (u32 i = thread_xy; i < LUT_SIZE; i += THREAD_COUNT) { s_half2_lut_global[i] = v; }
+  } else {
+#pragma unroll
+    for (u32 i = thread_xy; i < LUT_SIZE; i += THREAD_COUNT) {
+      const auto v = make_half2(__int2half_rd(i & 0b111u), __int2half_rd((i >> 3u) & 0b111u));
+      s_half2_lut_global[i] = v;
+    }
+  }
+
+  auto s_half2_lut = s_half2_lut_global + ((thread_xy / WARP_SIZE) << 6);
+
+  const u32 tile_row_id = blockIdx.x * BLOCK_HEIGHT + threadIdx.y;
+
+  // Number of SPQR tiles that this CUDA block will process.
+  u32 num_tiles_per_tile_row = UPDIV(prob_n, BETA2);
+
+  // Here is how we organize things here. We have THREAD_COUNT threads in a
+  // block in x-dimension. We distribute 1 thread per tile row. Therefore, we
+  // have BETA1 threads per tile. For now, a block only spans across 1 dimension
+  // of SPQR tiles.
+  constexpr u32 NUM_SPQR_TILES_PER_ITERATION = BLOCK_WIDTH;
+  constexpr u32 WARP_COUNT = UPDIV(BLOCK_WIDTH, 2);
+
+  u32 row_pos = thread_xy & 0xF;
+  const u32 subtile_id = threadIdx.x / BETA1;
+
+  auto raw_data_offset = tile_row_id * prob_n + threadIdx.x;
+
+  constexpr u32 FULL_MASK = 0xffffffff;
+  constexpr u32 HALF_MASK = FULL_MASK >> 16u;
+
+  constexpr static unsigned long long int NUM_USEFUL_BITS = 18ull * static_cast<u64>(BITS);
+  constexpr static int OFFSET = BETA1 / SECOND_ORDER_FRAGMENT_SIZE_BITS;
+
+  float acc{};
+
+  const auto* in_order_u32 = reinterpret_cast<const ushort2*>(in_order);
+
+  // Here we load the row offsets into smem.
+  for (u32 i = thread_xy; i <= ROW_OFFSETS_SIZE; i += THREAD_COUNT) {
+    __pipeline_memcpy_async(s_row_offsets + i, row_offsets + blockIdx.x * ROW_OFFSETS_SIZE + i, sizeof(u32));
+  }
+  __pipeline_commit();
+
+  __syncthreads();
+
+  u32 i = subtile_id, pipeline_id{};
+  const W_t *local_raw_data = dense_matrix + raw_data_offset;
+
+  for (u32 x2_id = thread_xy, it = 0;
+       it < UPDIV(prob_n / X_LOAD_BLOCK_SIZE, BLOCK_HEIGHT * BLOCK_WIDTH * HALF_WARP_SIZE); it++) {
+    u32 idx = pipeline_id * THREAD_COUNT + thread_xy;
+
+    RowBits row_bits{};
+    half2 ws2{};
+    half2 wz2{};
+
+    bool p = idx < (prob_n / X_LOAD_BLOCK_SIZE);
+
+    if (p) {
+      auto in_order = in_order_u32[idx];
+      if (in_order.x != 2 * idx || in_order.y != 2 * idx + 1) {
+        printf("%d %d %d %d\n", 2 * idx, 2 * idx + 1, in_order_u32[idx].x, in_order_u32[idx].y);
+      }
+      s_x2[idx] = make_half2(x[in_order.x], x[in_order.y]);
+    }
+
+    auto v = __ldg(local_raw_data);
+    row_bits.mask = v;
+    uint64_t s_order_partial =
+        (row_bits.mask >> NUM_USEFUL_BITS) << (SECOND_ORDER_FRAGMENT_SIZE_BITS * (row_pos / OFFSET));
+    SecondOrder _s{.v = recover_second_order_sync(s_order_partial)};
+    half2 first_order_quantized = INT2_TO_HALF2(row_bits.get_w2(0));
+    half2 first_order_dequantized = dequantize2(first_order_quantized, _s.get_sws2(), _s.get_swz2());
+
+    ws2 = __half2half2(first_order_dequantized.x);
+    wz2 = __half2half2(first_order_dequantized.y);
+
+    const auto s_x2_ = s_x2 + i * (BETA2 >> 1);
+    __syncthreads();
+
+#pragma unroll
+    for (u32 j = 0; j < BETA2 / 2; j++) {
+      half2 w_q = INT2_TO_HALF2(row_bits.get_w2(j + 1));
+      half2 w = dequantize2(w_q, ws2, wz2);
+      float2 x_fp32 = __half22float2(s_x2_[j]);
+      float2 w_fp32 = __half22float2(w);
+      acc = fmaf(x_fp32.x, w_fp32.x, acc);
+      acc = fmaf(x_fp32.y, w_fp32.y, acc);
+    }
+    i += NUM_SPQR_TILES_PER_ITERATION;
+    local_raw_data += NUM_SPQR_TILES_PER_ITERATION * BETA1;
+    x2_id += NUM_SPQR_TILES_PER_ITERATION * BETA1;
+    pipeline_id++;
+  }
+
+  for (; i < num_tiles_per_tile_row; i += NUM_SPQR_TILES_PER_ITERATION, local_raw_data +=
+                                     NUM_SPQR_TILES_PER_ITERATION * BETA1) {
+    auto v = __ldg(local_raw_data);
+    RowBits row_bits{
+      .mask = v
+    };
+    uint64_t s_order_partial =
+        (row_bits.mask >> NUM_USEFUL_BITS) << (SECOND_ORDER_FRAGMENT_SIZE_BITS * (row_pos / OFFSET));
+    SecondOrder _s{.v = recover_second_order_sync(s_order_partial)};
+    half2 first_order_quantized = INT2_TO_HALF2(row_bits.get_w2(0));
+    half2 first_order_dequantized = dequantize2(first_order_quantized, _s.get_sws2(), _s.get_swz2());
+
+    half2 ws2 = __half2half2(first_order_dequantized.x);
+    half2 wz2 = __half2half2(first_order_dequantized.y);
+
+    const auto s_x2_ = s_x2 + i * (BETA2 >> 1);
+
+#pragma unroll
+    for (u32 j = 0; j < BETA2 / 2; j++) {
+      half2 w_q = INT2_TO_HALF2(row_bits.get_w2(j + 1u));
+      half2 w = dequantize2(w_q, ws2, wz2);
+      float2 x_fp32 = __half22float2(s_x2_[j]);
+      float2 w_fp32 = __half22float2(w);
+      acc = fmaf(x_fp32.x, w_fp32.x, acc);
+      acc = fmaf(x_fp32.y, w_fp32.y, acc);
+    }
+  }
+
+  cp_async_wait<0>();
+
+  if constexpr (IS_CSR) {
+    u32 t = threadIdx.y * BETA1 + row_pos;
+    u32 s = s_row_offsets[t];
+    u32 e = s_row_offsets[t + 1];
+    half *s_x = reinterpret_cast<half *>(s_x2);
+    for (u32 i = s + subtile_id; i < e; i += BLOCK_WIDTH) {
+      ColVal colval{
+        ._ = __ldg(col_vals + i)
+      };
+      auto c = colval.members.c;
+      auto v = colval.members.v;
+      acc += __half2float(v) * __half2float(s_x[c]);
+    }
+  } else {
+    u32 s = s_row_offsets[0];
+    u32 e = s_row_offsets[1];
+
+    if (e - s) {
+      half *s_x = reinterpret_cast<half *>(s_x2);
+
+      if (s + thread_xy < e) {
+        ColVal colval{._ = col_vals[s + thread_xy]};
+        auto c = colval.members.c;
+        auto v = colval.members.v;
+        acc += __half2float(v) * __half2float(s_x[c]);
+      }
+
+      for (u32 i = s + thread_xy + BLOCK_WIDTH * BETA1; i < e; i += BLOCK_WIDTH * BETA1) {
+        ColVal colval{
+          ._ = col_vals[i]
+        };
+
+        if (!colval._) break;
+
+        auto c = colval.members.c;
+        auto v = colval.members.v;
+        acc += __half2float(v) * __half2float(s_x[c]);
+      }
+    }
+  }
+
+  __syncthreads();
+  auto other = __shfl_down_sync(HALF_MASK, acc, BETA1);
+  acc = add_and_accum(other, acc);
+
+  auto *s_fp32_buff = reinterpret_cast<float *>(s_half2_lut_global + threadIdx.y * MAX(WARP_SIZE - 1, 1) * BETA1);
+
+  u32 subwarp_id = threadIdx.x / WARP_SIZE;
+  if (subwarp_id >= 1 && threadIdx.x % WARP_SIZE < BETA1) {
+    s_fp32_buff[(subwarp_id - 1) * BETA1 + threadIdx.x % WARP_SIZE] = acc;
+  }
+
+  __syncthreads();
+
+  if (!subtile_id && threadIdx.x < BETA1) {
+    for (int i = 0; i < WARP_COUNT - 1; i++) {
+      acc += s_fp32_buff[i * BETA1 + threadIdx.x];
+    }
+  }
+
+  if (threadIdx.x < BETA1) {
+    y_fp16[tile_row_id * BETA1 + threadIdx.x] = __float2half(acc);
+  }
+}
+
+template<int BITS, int BETA1, int BETA2, int BLOCK_HEIGHT, int BLOCK_WIDTH, class W_t /* = uint64_t */, int
+  PIPELINE_DEPTH, bool IS_CSR> __global__ void spqr_quantized_matvec(
   // W and meta
   unsigned int prob_m,
   unsigned int prob_n,
@@ -187,7 +441,6 @@ template<int BITS, int BETA1, int BETA2, int BLOCK_HEIGHT, int BLOCK_WIDTH, clas
   // Outliers
   const int *__restrict__ row_offsets,
   const u32 *__restrict__ col_vals,
-  const short *__restrict__ order,
   // Output
   half *__restrict__ y_fp16) {
   /*
@@ -423,15 +676,8 @@ template<int BITS, int BETA1, int BETA2, int BLOCK_HEIGHT, int BLOCK_WIDTH, clas
     }
   }
 
-  if (order == nullptr) {
-    if (threadIdx.x < BETA1) {
-      y_fp16[tile_row_id * BETA1 + threadIdx.x] = __float2half(acc);
-    }
-  } else {
-    if (threadIdx.x < BETA1) {
-      short row = order[tile_row_id * BETA1 + threadIdx.x];
-      y_fp16[row] = __float2half_rn(acc);
-    }
+  if (threadIdx.x < BETA1) {
+    y_fp16[tile_row_id * BETA1 + threadIdx.x] = __float2half(acc);
   }
 }
 
@@ -467,7 +713,8 @@ int spqr_matvec(
   // Quantization
   int beta1,
   int beta2,
-  const void *raw_data,
+  const void *raw_in_order,
+  const void *raw_dense_data,
   // 32-bit
   int row_offsets_len,
   void *row_offsets,
@@ -477,7 +724,6 @@ int spqr_matvec(
   // 16-bit
   // Input
   void *X,
-  void *order,
   // Output
   void *y,
   cudaStream_t stream,
@@ -495,45 +741,77 @@ int spqr_matvec(
 
   Features features{._ = feature_flag};
 
-  const auto *raw_data_ptr = (const u64 *) raw_data;
+  const auto *raw_data_ptr = (const u64 *) raw_dense_data;
   const half *X_ptr = (const half *) X;
   const int *row_offsets_ptr = (const int *) row_offsets;
   half *y_ptr = (half *) y;
   const auto *col_vals_ptr = (const u32 *) col_vals;
-  const auto *order_ptr = (const short *) order;
+  const auto *order_ptr = (const uint16_t *) raw_in_order;
 
   int ret = 0;
 
   bool is_csr = prob_m + 1 == row_offsets_len;
 
 
-  if (is_csr) {
-    if (prob_m % 16 == 0 && prob_n % 512 == 0) {
-      CALL_FUSED(spqr_quantized_matvec_fused_csr, 1, 16, 1, true);
-    } else if (prob_m % 16 == 0 && prob_n % 256 == 0) {
-      CALL_FUSED(spqr_quantized_matvec_fused_csr, 1, 16, 1, true);
-    } else if (prob_m % 16 == 0 && prob_n % 128 == 0) {
-      CALL_FUSED(spqr_quantized_matvec_fused_csr, 1, 8, 1, true);
-    } else if (prob_m % 16 == 0 && prob_n % 64 == 0) {
-      CALL_FUSED(spqr_quantized_matvec_fused_csr, 1, 4, 1, true);
-    } else if (prob_m % 16 == 0 && prob_n % 32 == 0) {
-      CALL_FUSED(spqr_quantized_matvec_fused_csr, 1, 2, 1, true);
+  if (order_ptr == nullptr) {
+    if (is_csr) {
+      if (prob_m % 16 == 0 && prob_n % 512 == 0) {
+        CALL_MATVEC(spqr_quantized_matvec, 1, 16, 1, true);
+      } else if (prob_m % 16 == 0 && prob_n % 256 == 0) {
+        CALL_MATVEC(spqr_quantized_matvec, 1, 16, 1, true);
+      } else if (prob_m % 16 == 0 && prob_n % 128 == 0) {
+        CALL_MATVEC(spqr_quantized_matvec, 1, 8, 1, true);
+      } else if (prob_m % 16 == 0 && prob_n % 64 == 0) {
+        CALL_MATVEC(spqr_quantized_matvec, 1, 4, 1, true);
+      } else if (prob_m % 16 == 0 && prob_n % 32 == 0) {
+        CALL_MATVEC(spqr_quantized_matvec, 1, 2, 1, true);
+      } else {
+        CALL_MATVEC(spqr_quantized_matvec, 1, 1, 1, true);
+      }
     } else {
-      CALL_FUSED(spqr_quantized_matvec_fused_csr, 1, 1, 1, true);
+      if (prob_m % 16 == 0 && prob_n % 512 == 0) {
+        CALL_MATVEC(spqr_quantized_matvec, 1, 16, 1, false);
+      } else if (prob_m % 16 == 0 && prob_n % 256 == 0) {
+        CALL_MATVEC(spqr_quantized_matvec, 1, 16, 1, false);
+      } else if (prob_m % 16 == 0 && prob_n % 128 == 0) {
+        CALL_MATVEC(spqr_quantized_matvec, 1, 8, 2, false);
+      } else if (prob_m % 16 == 0 && prob_n % 64 == 0) {
+        CALL_MATVEC(spqr_quantized_matvec, 1, 4, 1, false);
+      } else if (prob_m % 16 == 0 && prob_n % 32 == 0) {
+        CALL_MATVEC(spqr_quantized_matvec, 1, 2, 1, false);
+      } else {
+        CALL_MATVEC(spqr_quantized_matvec, 1, 1, 1, false);
+      }
     }
-  } else {
-    if (prob_m % 16 == 0 && prob_n % 512 == 0) {
-      CALL_FUSED(spqr_quantized_matvec_fused_csr, 1, 16, 1, false);
-    } else if (prob_m % 16 == 0 && prob_n % 256 == 0) {
-      CALL_FUSED(spqr_quantized_matvec_fused_csr, 1, 16, 1, false);
-    } else if (prob_m % 16 == 0 && prob_n % 128 == 0) {
-      CALL_FUSED(spqr_quantized_matvec_fused_csr, 1, 8, 2, false);
-    } else if (prob_m % 16 == 0 && prob_n % 64 == 0) {
-      CALL_FUSED(spqr_quantized_matvec_fused_csr, 1, 4, 1, false);
-    } else if (prob_m % 16 == 0 && prob_n % 32 == 0) {
-      CALL_FUSED(spqr_quantized_matvec_fused_csr, 1, 2, 1, false);
+  } else { 
+    if (is_csr) {
+      if (prob_m % 16 == 0 && prob_n % 512 == 0) {
+        CALL_FUSED(spqr_quantized_matvec_fused, 1, 16, 1, true);
+      } else if (prob_m % 16 == 0 && prob_n % 256 == 0) {
+        CALL_FUSED(spqr_quantized_matvec_fused, 1, 16, 1, true);
+      } else if (prob_m % 16 == 0 && prob_n % 128 == 0) {
+        CALL_FUSED(spqr_quantized_matvec_fused, 1, 8, 1, true);
+      } else if (prob_m % 16 == 0 && prob_n % 64 == 0) {
+        CALL_FUSED(spqr_quantized_matvec_fused, 1, 4, 1, true);
+      } else if (prob_m % 16 == 0 && prob_n % 32 == 0) {
+        CALL_FUSED(spqr_quantized_matvec_fused, 1, 2, 1, true);
+      } else {
+        CALL_FUSED(spqr_quantized_matvec_fused, 1, 1, 1, true);
+      }
     } else {
-      CALL_FUSED(spqr_quantized_matvec_fused_csr, 1, 1, 1, false);
+      if (prob_m % 16 == 0 && prob_n % 512 == 0) {
+        CALL_FUSED(spqr_quantized_matvec_fused, 1, 16, 1, false);
+      } else if (prob_m % 16 == 0 && prob_n % 256 == 0) {
+        CALL_FUSED(spqr_quantized_matvec_fused, 1, 16, 1, false);
+      } else if (prob_m % 16 == 0 && prob_n % 128 == 0) {
+        CALL_FUSED(spqr_quantized_matvec_fused, 1, 8, 2, false);
+      } else if (prob_m % 16 == 0 && prob_n % 64 == 0) {
+        CALL_FUSED(spqr_quantized_matvec_fused, 1, 4, 1, false);
+      } else if (prob_m % 16 == 0 && prob_n % 32 == 0) {
+        CALL_FUSED(spqr_quantized_matvec_fused, 1, 2, 1, false);
+      } else {
+        CALL_FUSED(spqr_quantized_matvec_fused, 1, 1, 1, false);
+      }
     }
   }
 


### PR DESCRIPTION
Adds support for the following:

* Fused reorder-matvec kernel for improved reorder kernel:

Benchmark end-to-end runs (s) (RTX 4060 mobile, context length = 4096):
```
No reorder CSR
		Minimum duration after caching initial input = 0.0273
		Mean duration after caching initial input = 0.0287
		Median duration after caching initial input = 0.0279
Identity reorder without fusion CSR
		Minimum duration after caching initial input = 0.0280
		Mean duration after caching initial input = 0.0303
		Median duration after caching initial input = 0.0293
Identity reorder with fusion CSR
		Minimum duration after caching initial input = 0.0279
		Mean duration after caching initial input = 0.0298
		Median duration after caching initial input = 0.0290
Uniform reorder without fusion CSR
		Minimum duration after caching initial input = 0.0308
		Mean duration after caching initial input = 0.0362
		Median duration after caching initial input = 0.0361
Uniform reorder with fusion CSR
		Minimum duration after caching initial input = 0.0329
		Mean duration after caching initial input = 0.0353
		Median duration after caching initial input = 0.0354
```